### PR TITLE
Uniform build system cmake to build all components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.18)
+project(MicroSim VERSION 1.0 LANGUAGES C CXX)
+
+# Global options
+option(BUILD_GRAND_POTENTIAL_SERIAL  "Build the Grand-Potential Serial solver"    ON)
+option(BUILD_GRAND_POTENTIAL_MPI     "Build the Grand-Potential MPI solver"       ON)
+option(BUILD_KKS_CUFFT               "Build the KKS cuFFT (CUDA) solver"          ON)
+option(BUILD_KKS_FD_CUDA_MPI         "Build the KKS FD CUDA MPI solver"           ON)
+option(BUILD_KKS_OPENCL              "Build the KKS OpenCL solver"                ON)
+option(BUILD_CAHN_HILLIARD_FFT_2D    "Build the Cahn-Hilliard FFT 2D solver"      ON)
+
+# Append local cmake/ directory to the module search path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+if(BUILD_GRAND_POTENTIAL_SERIAL)
+    add_subdirectory(Grand_Potential_Serial)
+endif()
+
+if(BUILD_GRAND_POTENTIAL_MPI)
+    add_subdirectory(Grand_Potential_MPI)
+endif()
+
+if(BUILD_KKS_CUFFT)
+    add_subdirectory(KKS_CuFFT)
+endif()
+
+if(BUILD_KKS_FD_CUDA_MPI)
+    add_subdirectory(KKS_FD_CUDA_MPI)
+endif()
+
+if(BUILD_KKS_OPENCL)
+    add_subdirectory(KKS_OpenCl)
+endif()
+
+if(BUILD_CAHN_HILLIARD_FFT_2D)
+    add_subdirectory(Cahn_Hilliard_FFT_2D)
+endif()

--- a/Cahn_Hilliard_FFT_2D/CMakeLists.txt
+++ b/Cahn_Hilliard_FFT_2D/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_ch_fft LANGUAGES C)
+
+# Add the top-level cmake/ directory to the module path so that
+# FindFFTW3.cmake is found whether this is built stand-alone or as part
+# of the top-level project.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+find_package(FFTW3 REQUIRED)   # provided by cmake/FindFFTW3.cmake
+
+# ── Main solver target ───────────────────────────────────────────────────────
+add_executable(microsim_ch_fft microsim_ch_fft.c)
+
+target_include_directories(microsim_ch_fft PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions
+    ${CMAKE_CURRENT_SOURCE_DIR}/solverloop
+    ${FFTW3_INCLUDE_DIRS}
+)
+
+target_link_libraries(microsim_ch_fft PRIVATE
+    FFTW3::fftw3
+    m
+)
+
+install(TARGETS microsim_ch_fft RUNTIME DESTINATION bin)

--- a/Grand_Potential_MPI/CMakeLists.txt
+++ b/Grand_Potential_MPI/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_gp_mpi LANGUAGES C)
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+find_package(MPI  REQUIRED COMPONENTS C)
+find_package(HDF5 REQUIRED COMPONENTS C HL)
+find_package(GSL  REQUIRED)
+
+# ── Main solver target ───────────────────────────────────────────────────────
+# The build consists of a single .c translation unit; all other files
+# in functions/, solverloop/ and tdbs/ are header-only includes.
+add_executable(microsim_gp microsim_gp.c)
+
+target_include_directories(microsim_gp PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions
+    ${CMAKE_CURRENT_SOURCE_DIR}/solverloop
+    ${CMAKE_CURRENT_SOURCE_DIR}/tdbs
+    ${HDF5_INCLUDE_DIRS}
+    ${GSL_INCLUDE_DIRS}
+)
+
+target_compile_definitions(microsim_gp PRIVATE ${HDF5_DEFINITIONS})
+
+target_link_libraries(microsim_gp PRIVATE
+    MPI::MPI_C
+    ${HDF5_C_LIBRARIES}
+    GSL::gsl
+    GSL::gslcblas
+    m
+)
+
+# ── write_xdmf utility ───────────────────────────────────────────────────────
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/write_xdmf.c")
+    add_executable(write_xdmf write_xdmf.c)
+
+    target_include_directories(write_xdmf PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/functions
+        ${CMAKE_CURRENT_SOURCE_DIR}/solverloop
+        ${HDF5_INCLUDE_DIRS}
+        ${GSL_INCLUDE_DIRS}
+    )
+
+    target_compile_definitions(write_xdmf PRIVATE ${HDF5_DEFINITIONS})
+
+    target_link_libraries(write_xdmf PRIVATE
+        MPI::MPI_C
+        ${HDF5_C_LIBRARIES}
+        GSL::gsl
+        GSL::gslcblas
+        m
+    )
+endif()
+
+install(TARGETS microsim_gp RUNTIME DESTINATION bin)

--- a/Grand_Potential_MPI/Makefile
+++ b/Grand_Potential_MPI/Makefile
@@ -2,12 +2,12 @@ FDIR=functions
 SDIR=solverloop
 TDIR=tdbs
 CC=h5pcc #-O3
-# CFLAGS=-I.
-#LDIR=$(GSL_ROOT_DIR)/lib
-#IDIR=$(GSL_ROOT_DIR)/include
 
-LDIR=/share/apps/gsl/lib
-IDIR=/share/apps/gsl/include
+# GSL paths: set GSL_ROOT_DIR to your GSL installation prefix.
+# If unset, the build tries to locate GSL via gsl-config.
+GSL_ROOT_DIR ?= $(shell gsl-config --prefix 2>/dev/null)
+LDIR=$(GSL_ROOT_DIR)/lib
+IDIR=$(GSL_ROOT_DIR)/include
 CFLAGS=-I $(IDIR)
 
 _FUNCTION_DEPS = global_vars.h functions.h matrix.h utility_functions.h functionH.h functionF_01.h functionF_02.h functionF_03.h functionF_04.h functionF_05.h  functionF_06.h functionQ.h \

--- a/Grand_Potential_Serial/CMakeLists.txt
+++ b/Grand_Potential_Serial/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_gp_serial LANGUAGES C)
+
+# Source files – the solver is a single translation unit; all other files
+# are header-only and referenced via include paths.
+add_executable(microsim_gp microsim_gp.c)
+
+target_include_directories(microsim_gp PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions
+    ${CMAKE_CURRENT_SOURCE_DIR}/solverloop
+)
+
+target_link_libraries(microsim_gp PRIVATE m)
+
+install(TARGETS microsim_gp RUNTIME DESTINATION bin)

--- a/KKS_CuFFT/CMakeLists.txt
+++ b/KKS_CuFFT/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_kks_cufft LANGUAGES CUDA)
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+find_package(CUDAToolkit REQUIRED)
+
+# ── Target ───────────────────────────────────────────────────────────────────
+add_executable(microsim_kks_cufft KKS_cuFFT.cu)
+
+# Optimisation flags passed through to ptxas (matches -Xptxas -O3 in Makefile)
+target_compile_options(microsim_kks_cufft PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas -O3>
+)
+
+# GPU architecture – default sm_70; override via -DCUDA_ARCH=<arch>
+if(NOT DEFINED CUDA_ARCH)
+    set(CUDA_ARCH "70")
+endif()
+set_target_properties(microsim_kks_cufft PROPERTIES
+    CUDA_ARCHITECTURES ${CUDA_ARCH}
+)
+
+target_include_directories(microsim_kks_cufft PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions
+)
+
+target_link_libraries(microsim_kks_cufft PRIVATE
+    CUDA::cufft
+    CUDA::cuda_driver
+    CUDA::cudart
+)
+
+# Create DATA output directory expected by the solver at run-time
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/DATA")
+
+install(TARGETS microsim_kks_cufft RUNTIME DESTINATION bin)

--- a/KKS_FD_CUDA_MPI/CMakeLists.txt
+++ b/KKS_FD_CUDA_MPI/CMakeLists.txt
@@ -1,0 +1,183 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_kks_fd_cuda_mpi LANGUAGES C CXX CUDA)
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+find_package(MPI         REQUIRED COMPONENTS C CXX)
+find_package(HDF5        REQUIRED COMPONENTS C HL)
+find_package(GSL         REQUIRED)
+find_package(CUDAToolkit REQUIRED)
+
+# ── Build options ─────────────────────────────────────────────────────────────
+option(ENABLE_HDF5    "Enable HDF5 output"        ON)
+option(ENABLE_CUFFTMP "Enable multi-GPU cuFFTMp"  OFF)
+
+# GPU architecture – default sm_70; override via -DCUDA_ARCH=<arch>
+if(NOT DEFINED CUDA_ARCH)
+    set(CUDA_ARCH "70")
+endif()
+
+# ── Helper: convenience path variables ───────────────────────────────────────
+set(FUNCTIONS  ${CMAKE_CURRENT_SOURCE_DIR}/functions)
+set(SOLVERLOOP ${CMAKE_CURRENT_SOURCE_DIR}/solverloop)
+set(TDBS       ${CMAKE_CURRENT_SOURCE_DIR}/tdbs)
+
+# ── Sources ──────────────────────────────────────────────────────────────────
+set(HOST_SOURCES
+    microsim_kks_fd_cuda_mpi.c
+    ${SOLVERLOOP}/fileWriter.c
+    ${FUNCTIONS}/utilityFunctions.c
+    ${FUNCTIONS}/initialize_variables.c
+    ${FUNCTIONS}/filling.c
+    ${FUNCTIONS}/reading_input_parameters.c
+    ${FUNCTIONS}/fill_domain.c
+    ${FUNCTIONS}/read_boundary_conditions.c
+    ${FUNCTIONS}/calc_bn.c
+    ${FUNCTIONS}/box_iterator.cpp
+    ${FUNCTIONS}/error_checks.cpp
+)
+
+set(DEVICE_SOURCES
+    ${TDBS}/Thermo.cu
+    ${FUNCTIONS}/functionF.cu
+    ${FUNCTIONS}/functionH.cu
+    ${FUNCTIONS}/functionTau.cu
+    ${FUNCTIONS}/functionW_02.cu
+    ${FUNCTIONS}/anisotropy_01.cu
+    ${FUNCTIONS}/functionA_01.cu
+    ${FUNCTIONS}/functionA_02.cu
+    ${FUNCTIONS}/matrix.cu
+    ${SOLVERLOOP}/utilityKernels.cu
+    ${SOLVERLOOP}/boundary.cu
+    ${SOLVERLOOP}/calcPhaseComp.cu
+    ${SOLVERLOOP}/smooth.cu
+    ${SOLVERLOOP}/computeDrivingForce.cu
+    ${SOLVERLOOP}/computeElastic.cu
+    ${SOLVERLOOP}/updateComposition.cu
+    ${SOLVERLOOP}/updatePhi.cu
+)
+
+# ── Target ───────────────────────────────────────────────────────────────────
+add_executable(microsim_kks_fd_cuda_mpi
+    ${HOST_SOURCES}
+    ${DEVICE_SOURCES}
+)
+
+# CUDA separable compilation handles the -dc / device-link steps automatically.
+set_target_properties(microsim_kks_fd_cuda_mpi PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_ARCHITECTURES         ${CUDA_ARCH}
+)
+
+# computeElastic requires C++17
+set_source_files_properties(${SOLVERLOOP}/computeElastic.cu
+    PROPERTIES COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:-std=c++17>"
+)
+
+# ── Include directories ──────────────────────────────────────────────────────
+target_include_directories(microsim_kks_fd_cuda_mpi PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${FUNCTIONS}
+    ${SOLVERLOOP}
+    ${TDBS}
+    ${HDF5_INCLUDE_DIRS}
+    ${GSL_INCLUDE_DIRS}
+    ${CUDAToolkit_INCLUDE_DIRS}
+)
+
+if(ENABLE_CUFFTMP)
+    # cuFFTMp headers are shipped with the HPC SDK; users can override the path.
+    if(NOT DEFINED CUFFTMP_INCLUDE_DIR)
+        message(WARNING "ENABLE_CUFFTMP=ON but CUFFTMP_INCLUDE_DIR is not set. "
+                        "Provide -DCUFFTMP_INCLUDE_DIR=<path> to the cuFFTMp headers.")
+    else()
+        target_include_directories(microsim_kks_fd_cuda_mpi PRIVATE ${CUFFTMP_INCLUDE_DIR})
+    endif()
+endif()
+
+# ── Compile definitions ───────────────────────────────────────────────────────
+target_compile_definitions(microsim_kks_fd_cuda_mpi PRIVATE
+    ENABLE_HDF5=$<BOOL:${ENABLE_HDF5}>
+    ENABLE_CUFFTMP=$<BOOL:${ENABLE_CUFFTMP}>
+    ${HDF5_DEFINITIONS}
+)
+
+# Suppress common NVHPC/nvcc diagnostic noise
+target_compile_options(microsim_kks_fd_cuda_mpi PRIVATE
+    $<$<COMPILE_LANGUAGE:CXX>:
+        --diag_suppress=declared_but_not_referenced
+        --diag_suppress=set_but_not_used>
+    $<$<COMPILE_LANGUAGE:C>:
+        --diag_suppress=declared_but_not_referenced
+        --diag_suppress=set_but_not_used>
+)
+
+# ── Link libraries ────────────────────────────────────────────────────────────
+target_link_libraries(microsim_kks_fd_cuda_mpi PRIVATE
+    MPI::MPI_CXX
+    GSL::gsl
+    GSL::gslcblas
+    CUDA::cudart
+    m
+)
+
+if(ENABLE_HDF5)
+    target_link_libraries(microsim_kks_fd_cuda_mpi PRIVATE ${HDF5_C_LIBRARIES})
+endif()
+
+if(ENABLE_CUFFTMP)
+    # cuFFTMp – library location can be overridden with -DCUFFTMP_LIB_DIR=<path>
+    if(DEFINED CUFFTMP_LIB_DIR)
+        target_link_directories(microsim_kks_fd_cuda_mpi PRIVATE ${CUFFTMP_LIB_DIR})
+    endif()
+    target_link_libraries(microsim_kks_fd_cuda_mpi PRIVATE cufftMp)
+else()
+    target_link_libraries(microsim_kks_fd_cuda_mpi PRIVATE CUDA::cufft)
+endif()
+
+# ── Utility: write_xdmf ──────────────────────────────────────────────────────
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/write_xdmf.c")
+    add_executable(write_xdmf_kks write_xdmf.c)
+
+    target_include_directories(write_xdmf_kks PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${FUNCTIONS}
+        ${SOLVERLOOP}
+        ${HDF5_INCLUDE_DIRS}
+        ${CUDAToolkit_INCLUDE_DIRS}
+    )
+
+    target_compile_definitions(write_xdmf_kks PRIVATE
+        THERMO=0
+        ENABLE_HDF5=$<BOOL:${ENABLE_HDF5}>
+        ${HDF5_DEFINITIONS}
+    )
+
+    target_link_libraries(write_xdmf_kks PRIVATE
+        MPI::MPI_CXX
+        ${HDF5_C_LIBRARIES}
+        CUDA::cudart
+        m
+    )
+endif()
+
+# ── Utility: reconstruct ──────────────────────────────────────────────────────
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/reconstruct.c")
+    add_executable(reconstruct_kks reconstruct.c)
+
+    target_include_directories(reconstruct_kks PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${FUNCTIONS}
+        ${SOLVERLOOP}
+        ${CUDAToolkit_INCLUDE_DIRS}
+    )
+
+    target_compile_definitions(reconstruct_kks PRIVATE THERMO=0)
+
+    target_link_libraries(reconstruct_kks PRIVATE
+        MPI::MPI_CXX
+        CUDA::cudart
+        m
+    )
+endif()
+
+install(TARGETS microsim_kks_fd_cuda_mpi RUNTIME DESTINATION bin)

--- a/KKS_FD_CUDA_MPI/Makefile
+++ b/KKS_FD_CUDA_MPI/Makefile
@@ -4,15 +4,21 @@ NPROCS = 1
 
 HPCSDK_VERSION ?= 23.3
 
-NVHPC_ROOT       ?= /opt/nvidia
-NVHPC_HOME       ?= ${NVHPC_ROOT}/hpc_sdk/Linux_x86_64/${HPCSDK_VERSION}
+NVHPC_ROOT       ?= /opt/nvidia/hpc_sdk
+NVHPC_HOME       ?= ${NVHPC_ROOT}/Linux_x86_64/${HPCSDK_VERSION}
 NVHPC_CUDA_HOME  ?= ${NVHPC_HOME}/cuda
 MPI_HOME         ?= ${NVHPC_HOME}/comm_libs/openmpi4/openmpi-4.0.5
-HDF5_HOME        ?= /opt/spack/opt/spack/linux-ubuntu22.04-skylake_avx512/gcc-11.4.0/hdf5-1.14.4-3-bqhpg7nw6szqeigw5dmlvhhmrspezu7h
+# Set HDF5_HOME to the root of your HDF5 installation (e.g. /opt/hdf5 or
+# the output of "spack location -i hdf5").  Example:
+#   make HDF5_HOME=/opt/hdf5
+HDF5_HOME        ?=
 CUFFT_LIB        ?= ${NVHPC_HOME}/math_libs/lib64
 CUFFT_INC        ?= ${NVHPC_HOME}/math_libs/include/cufftmp
 NVSHMEM_LIB      ?= ${NVHPC_HOME}/math_libs/12.0/lib64/compat/nvshmem_2.6.0-1
-GSL_HOME         ?= /opt/spack/opt/spack/linux-ubuntu22.04-skylake_avx512/gcc-11.4.0/gsl-2.7.1-wwnnm54dtynjeyuzdt24v7dfbgy4kjhv
+# Set GSL_HOME to the root of your GSL installation (e.g. /usr or
+# the output of "gsl-config --prefix").  Example:
+#   make GSL_HOME=/usr/local
+GSL_HOME         ?=
 
 # Arguments
 INPUT = Input_austenite_ferrite.in

--- a/KKS_OpenCl/CMakeLists.txt
+++ b/KKS_OpenCl/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.18)
+project(microsim_kks_opencl LANGUAGES C)
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+find_package(MPI    REQUIRED COMPONENTS C)
+find_package(OpenCL REQUIRED)
+find_package(HDF5   REQUIRED COMPONENTS C HL)
+find_package(GSL    REQUIRED)
+
+# ── Main solver target ───────────────────────────────────────────────────────
+# Single-translation-unit C solver; functions/, solverloop/ and tdbs/ are
+# header-only includes.
+add_executable(microsim_kks_opencl microsim_kks_opencl.c)
+
+target_include_directories(microsim_kks_opencl PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions
+    ${CMAKE_CURRENT_SOURCE_DIR}/solverloop
+    ${CMAKE_CURRENT_SOURCE_DIR}/tdbs
+    ${HDF5_INCLUDE_DIRS}
+    ${GSL_INCLUDE_DIRS}
+)
+
+target_compile_definitions(microsim_kks_opencl PRIVATE ${HDF5_DEFINITIONS})
+
+target_link_libraries(microsim_kks_opencl PRIVATE
+    MPI::MPI_C
+    OpenCL::OpenCL
+    GSL::gsl
+    GSL::gslcblas
+    ${HDF5_C_LIBRARIES}
+    m
+)
+
+# ── reconstruct utility ───────────────────────────────────────────────────────
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/reconstruct.c")
+    add_executable(reconstruct_opencl reconstruct.c)
+
+    target_include_directories(reconstruct_opencl PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/functions
+        ${HDF5_INCLUDE_DIRS}
+        ${GSL_INCLUDE_DIRS}
+    )
+
+    target_compile_definitions(reconstruct_opencl PRIVATE ${HDF5_DEFINITIONS})
+
+    target_link_libraries(reconstruct_opencl PRIVATE
+        MPI::MPI_C
+        OpenCL::OpenCL
+        GSL::gsl
+        GSL::gslcblas
+        ${HDF5_C_LIBRARIES}
+        m
+    )
+endif()
+
+install(TARGETS microsim_kks_opencl RUNTIME DESTINATION bin)

--- a/KKS_OpenCl/Makefile
+++ b/KKS_OpenCl/Makefile
@@ -3,9 +3,15 @@ SDIR=solverloop
 TDIR=tdbs
 CC=mpicc
 HC=h5pcc
-CFLAGS=-I. -I$(HOME)/gsl_2_7/include/ -I/usr/local/cuda/include/ -I/usr/include/hdf5/openmpi/
 
-LDIR =-L/usr/local/cuda/lib64/  -L$(HOME)/gsl_2_7/lib/
+# Override these variables to match your system's library installation paths.
+# Defaults attempt auto-detection via standard tool wrappers.
+CUDA_HOME    ?= /usr/local/cuda
+GSL_ROOT_DIR ?= $(shell gsl-config --prefix 2>/dev/null)
+HDF5_INC_DIR ?= $(shell pkg-config --variable=includedir hdf5 2>/dev/null)
+
+CFLAGS=-I. -I$(GSL_ROOT_DIR)/include -I$(CUDA_HOME)/include -I$(HDF5_INC_DIR)
+LDIR =-L$(CUDA_HOME)/lib64 -L$(GSL_ROOT_DIR)/lib
 
 _FUNCTION_DEPS = global_vars.h CL_global_vars.h CL_initialize_variables.h      \
                  CL_device_kernel_build.h CL_buffer_allocation.h CL_create_kernel_args.h  \

--- a/cmake/FindFFTW3.cmake
+++ b/cmake/FindFFTW3.cmake
@@ -1,0 +1,54 @@
+# FindFFTW3.cmake
+#
+# Finds the FFTW3 double-precision library.
+#
+# Imported target:
+#   FFTW3::fftw3
+#
+# Result variables:
+#   FFTW3_FOUND         - TRUE if FFTW3 was found
+#   FFTW3_INCLUDE_DIRS  - include directory
+#   FFTW3_LIBRARIES     - libraries to link against
+#
+# Search hints (can be set by the user before calling find_package):
+#   FFTW3_ROOT           - root installation prefix
+
+# --- header ---
+find_path(FFTW3_INCLUDE_DIR
+    NAMES fftw3.h
+    HINTS
+        ${FFTW3_ROOT}
+        ENV FFTW3_ROOT
+        ENV FFTW3_DIR
+    PATH_SUFFIXES include
+)
+
+# --- library ---
+find_library(FFTW3_LIBRARY
+    NAMES fftw3
+    HINTS
+        ${FFTW3_ROOT}
+        ENV FFTW3_ROOT
+        ENV FFTW3_DIR
+    PATH_SUFFIXES lib lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFTW3
+    REQUIRED_VARS FFTW3_LIBRARY FFTW3_INCLUDE_DIR
+)
+
+if(FFTW3_FOUND)
+    set(FFTW3_INCLUDE_DIRS ${FFTW3_INCLUDE_DIR})
+    set(FFTW3_LIBRARIES    ${FFTW3_LIBRARY})
+
+    if(NOT TARGET FFTW3::fftw3)
+        add_library(FFTW3::fftw3 UNKNOWN IMPORTED)
+        set_target_properties(FFTW3::fftw3 PROPERTIES
+            IMPORTED_LOCATION             "${FFTW3_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${FFTW3_INCLUDE_DIR}"
+        )
+    endif()
+endif()
+
+mark_as_advanced(FFTW3_INCLUDE_DIR FFTW3_LIBRARY)

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -16,12 +16,12 @@ build system.  The original `Makefile`s are retained alongside the new
 5. [Building Individual Solvers](#building-individual-solvers)
 6. [Configuration Options](#configuration-options)
 7. [Solver-Specific Notes](#solver-specific-notes)
-   - [Grand\_Potential\_Serial](#grand_potential_serial)
-   - [Grand\_Potential\_MPI](#grand_potential_mpi)
-   - [KKS\_CuFFT](#kks_cufft)
-   - [KKS\_FD\_CUDA\_MPI](#kks_fd_cuda_mpi)
-   - [KKS\_OpenCl](#kks_opencl)
-   - [Cahn\_Hilliard\_FFT\_2D](#cahn_hilliard_fft_2d)
+   - [Grand_Potential_Serial](#grand_potential_serial)
+   - [Grand_Potential_MPI](#grand_potential_mpi)
+   - [KKS_CuFFT](#kks_cufft)
+   - [KKS_FD_CUDA_MPI](#kks_fd_cuda_mpi)
+   - [KKS_OpenCl](#kks_opencl)
+   - [Cahn_Hilliard_FFT_2D](#cahn_hilliard_fft_2d)
 8. [Out-of-Scope Modules](#out-of-scope-modules)
 9. [Troubleshooting](#troubleshooting)
 
@@ -48,13 +48,13 @@ inside each solver subdirectory.  This caused several pain points:
 |---|---|---|
 | CMake | 3.18 | all |
 | C compiler (GCC, Clang, NVHPC) | C11 | all |
-| C++ compiler | C++17 | KKS\_FD\_CUDA\_MPI |
-| CUDA Toolkit | 11.0 | KKS\_CuFFT, KKS\_FD\_CUDA\_MPI |
-| MPI (OpenMPI / MPICH) | any | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
-| HDF5 (parallel build) | 1.10+ | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
-| GSL | 2.0+ | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
-| OpenCL | 1.2+ | KKS\_OpenCl |
-| FFTW3 | 3.x | Cahn\_Hilliard\_FFT\_2D |
+| C++ compiler | C++17 | KKS_FD_CUDA_MPI |
+| CUDA Toolkit | 11.0 | KKS_CuFFT, KKS_FD_CUDA_MPI |
+| MPI (OpenMPI / MPICH) | any | Grand_Potential_MPI, KKS_FD_CUDA_MPI, KKS_OpenCl |
+| HDF5 (parallel build) | 1.10+ | Grand_Potential_MPI, KKS_FD_CUDA_MPI, KKS_OpenCl |
+| GSL | 2.0+ | Grand_Potential_MPI, KKS_FD_CUDA_MPI, KKS_OpenCl |
+| OpenCL | 1.2+ | KKS_OpenCl |
+| FFTW3 | 3.x | Cahn_Hilliard_FFT_2D |
 
 ---
 
@@ -164,8 +164,8 @@ cmake --build build -j8
 | `BUILD_KKS_OPENCL` | `ON` | Build the KKS OpenCL solver |
 | `BUILD_CAHN_HILLIARD_FFT_2D` | `ON` | Build the Cahn-Hilliard FFT 2D solver |
 | `CUDA_ARCH` | `70` | CUDA GPU architecture (e.g. `70`, `80`, `90`) |
-| `ENABLE_HDF5` *(KKS\_FD\_CUDA\_MPI)* | `ON` | Enable HDF5 output |
-| `ENABLE_CUFFTMP` *(KKS\_FD\_CUDA\_MPI)* | `OFF` | Enable multi-GPU cuFFTMp support |
+| `ENABLE_HDF5` *(KKS_FD_CUDA_MPI)* | `ON` | Enable HDF5 output |
+| `ENABLE_CUFFTMP` *(KKS_FD_CUDA_MPI)* | `OFF` | Enable multi-GPU cuFFTMp support |
 | `CUFFTMP_INCLUDE_DIR` | *(unset)* | Path to cuFFTMp headers (needed when `ENABLE_CUFFTMP=ON`) |
 | `CUFFTMP_LIB_DIR` | *(unset)* | Path to cuFFTMp library (needed when `ENABLE_CUFFTMP=ON`) |
 | `FFTW3_ROOT` | *(unset)* | Hint path for FFTW3 installation prefix |
@@ -180,7 +180,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
 
 ## Solver-Specific Notes
 
-### Grand\_Potential\_Serial
+### Grand_Potential_Serial
 
 - **Languages**: C
 - **Dependencies**: libm (standard library)
@@ -188,7 +188,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
 - The solver is a single-translation-unit program; all `functions/` and
   `solverloop/` files are header-only includes.
 
-### Grand\_Potential\_MPI
+### Grand_Potential_MPI
 
 - **Languages**: C
 - **Dependencies**: MPI, HDF5 (parallel), GSL
@@ -200,7 +200,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
   cmake -S . -B build -DGSL_ROOT_DIR=/path/to/gsl
   ```
 
-### KKS\_CuFFT
+### KKS_CuFFT
 
 - **Languages**: CUDA
 - **Dependencies**: CUDA Toolkit (cuFFT)
@@ -209,7 +209,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
   the solver's expected output path.
 - Set the target GPU architecture with `-DCUDA_ARCH=<sm>` (default: `70`).
 
-### KKS\_FD\_CUDA\_MPI
+### KKS_FD_CUDA_MPI
 
 - **Languages**: C, C++, CUDA
 - **Dependencies**: MPI, HDF5, GSL, CUDA Toolkit (cuFFT or cuFFTMp)
@@ -225,7 +225,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
         -DCUFFTMP_LIB_DIR=/opt/nvidia/hpc_sdk/.../math_libs/lib64
   ```
 
-### KKS\_OpenCl
+### KKS_OpenCl
 
 - **Languages**: C
 - **Dependencies**: MPI, OpenCL, HDF5, GSL
@@ -236,7 +236,7 @@ cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=O
   cmake -S . -B build -DOpenCL_ROOT=/usr/local/cuda
   ```
 
-### Cahn\_Hilliard\_FFT\_2D
+### Cahn_Hilliard_FFT_2D
 
 - **Languages**: C
 - **Dependencies**: FFTW3

--- a/docs/cmake_upgrade.md
+++ b/docs/cmake_upgrade.md
@@ -1,0 +1,330 @@
+# CMake Build System Upgrade
+
+This document describes the migration of the **MicroSim** build system from a
+collection of hand-written `Makefile`s to a unified [CMake](https://cmake.org/)
+build system.  The original `Makefile`s are retained alongside the new
+`CMakeLists.txt` files to ease the transition.
+
+---
+
+## Table of Contents
+
+1. [Motivation](#motivation)
+2. [Prerequisites](#prerequisites)
+3. [Repository Layout](#repository-layout)
+4. [Quick Start](#quick-start)
+5. [Building Individual Solvers](#building-individual-solvers)
+6. [Configuration Options](#configuration-options)
+7. [Solver-Specific Notes](#solver-specific-notes)
+   - [Grand\_Potential\_Serial](#grand_potential_serial)
+   - [Grand\_Potential\_MPI](#grand_potential_mpi)
+   - [KKS\_CuFFT](#kks_cufft)
+   - [KKS\_FD\_CUDA\_MPI](#kks_fd_cuda_mpi)
+   - [KKS\_OpenCl](#kks_opencl)
+   - [Cahn\_Hilliard\_FFT\_2D](#cahn_hilliard_fft_2d)
+8. [Out-of-Scope Modules](#out-of-scope-modules)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Motivation
+
+The previous build system consisted of independent, hand-crafted `Makefile`s
+inside each solver subdirectory.  This caused several pain points:
+
+| Problem | CMake Solution |
+|---|---|
+| Hard-coded library paths (`/share/apps/gsl/lib`) | `find_package()` locates libraries portably |
+| No out-of-source build support | CMake separates source and build trees by default |
+| Compiler flags duplicated across solvers | Shared CMake logic and variables |
+| No way to build all solvers in one step | Top-level `CMakeLists.txt` with `add_subdirectory()` |
+| No install support | `install()` targets for all executables |
+
+---
+
+## Prerequisites
+
+| Dependency | Minimum version | Required by |
+|---|---|---|
+| CMake | 3.18 | all |
+| C compiler (GCC, Clang, NVHPC) | C11 | all |
+| C++ compiler | C++17 | KKS\_FD\_CUDA\_MPI |
+| CUDA Toolkit | 11.0 | KKS\_CuFFT, KKS\_FD\_CUDA\_MPI |
+| MPI (OpenMPI / MPICH) | any | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
+| HDF5 (parallel build) | 1.10+ | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
+| GSL | 2.0+ | Grand\_Potential\_MPI, KKS\_FD\_CUDA\_MPI, KKS\_OpenCl |
+| OpenCL | 1.2+ | KKS\_OpenCl |
+| FFTW3 | 3.x | Cahn\_Hilliard\_FFT\_2D |
+
+---
+
+## Repository Layout
+
+```
+MicroSim/
+├── CMakeLists.txt                  ← NEW top-level CMake entry point
+├── cmake/
+│   └── FindFFTW3.cmake             ← NEW custom FFTW3 find module
+├── docs/
+│   └── cmake_upgrade.md            ← this document
+│
+├── Grand_Potential_Serial/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── Grand_Potential_MPI/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── KKS_CuFFT/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── KKS_FD_CUDA_MPI/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── KKS_OpenCl/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── Cahn_Hilliard_FFT_2D/
+│   ├── CMakeLists.txt              ← NEW
+│   └── Makefile                    ← original (retained)
+│
+├── Grand_potential_AMReX/          ← uses AMReX GNUmake (unchanged)
+└── Grand_potential_OpenFOAM/       ← uses OpenFOAM wmake (unchanged)
+```
+
+---
+
+## Quick Start
+
+### Build all solvers
+
+```bash
+# 1. Clone the repository (or enter the existing clone)
+cd MicroSim
+
+# 2. Create an out-of-source build directory
+cmake -S . -B build
+
+# 3. Compile (replace 8 with the number of CPU cores available)
+cmake --build build -j8
+
+# 4. (Optional) Install executables to /usr/local/bin
+cmake --install build
+```
+
+To change the install prefix:
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=$HOME/.local
+cmake --build build -j8
+cmake --install build
+```
+
+---
+
+## Building Individual Solvers
+
+You can configure CMake to build only the solvers you need:
+
+```bash
+# Build only the serial Grand-Potential solver
+cmake -S . -B build \
+      -DBUILD_GRAND_POTENTIAL_SERIAL=ON  \
+      -DBUILD_GRAND_POTENTIAL_MPI=OFF    \
+      -DBUILD_KKS_CUFFT=OFF             \
+      -DBUILD_KKS_FD_CUDA_MPI=OFF       \
+      -DBUILD_KKS_OPENCL=OFF            \
+      -DBUILD_CAHN_HILLIARD_FFT_2D=OFF
+cmake --build build -j8
+```
+
+Alternatively, change into a specific subdirectory and invoke CMake
+independently:
+
+```bash
+cd Grand_Potential_Serial
+cmake -S . -B build
+cmake --build build -j8
+```
+
+---
+
+## Configuration Options
+
+| CMake option | Default | Description |
+|---|---|---|
+| `BUILD_GRAND_POTENTIAL_SERIAL` | `ON` | Build the serial Grand-Potential solver |
+| `BUILD_GRAND_POTENTIAL_MPI` | `ON` | Build the MPI Grand-Potential solver |
+| `BUILD_KKS_CUFFT` | `ON` | Build the KKS cuFFT solver |
+| `BUILD_KKS_FD_CUDA_MPI` | `ON` | Build the KKS FD CUDA MPI solver |
+| `BUILD_KKS_OPENCL` | `ON` | Build the KKS OpenCL solver |
+| `BUILD_CAHN_HILLIARD_FFT_2D` | `ON` | Build the Cahn-Hilliard FFT 2D solver |
+| `CUDA_ARCH` | `70` | CUDA GPU architecture (e.g. `70`, `80`, `90`) |
+| `ENABLE_HDF5` *(KKS\_FD\_CUDA\_MPI)* | `ON` | Enable HDF5 output |
+| `ENABLE_CUFFTMP` *(KKS\_FD\_CUDA\_MPI)* | `OFF` | Enable multi-GPU cuFFTMp support |
+| `CUFFTMP_INCLUDE_DIR` | *(unset)* | Path to cuFFTMp headers (needed when `ENABLE_CUFFTMP=ON`) |
+| `CUFFTMP_LIB_DIR` | *(unset)* | Path to cuFFTMp library (needed when `ENABLE_CUFFTMP=ON`) |
+| `FFTW3_ROOT` | *(unset)* | Hint path for FFTW3 installation prefix |
+
+Options are passed to CMake using the `-D` flag, for example:
+
+```bash
+cmake -S . -B build -DCUDA_ARCH=80 -DBUILD_KKS_FD_CUDA_MPI=ON -DENABLE_CUFFTMP=OFF
+```
+
+---
+
+## Solver-Specific Notes
+
+### Grand\_Potential\_Serial
+
+- **Languages**: C
+- **Dependencies**: libm (standard library)
+- **Executables produced**: `microsim_gp`
+- The solver is a single-translation-unit program; all `functions/` and
+  `solverloop/` files are header-only includes.
+
+### Grand\_Potential\_MPI
+
+- **Languages**: C
+- **Dependencies**: MPI, HDF5 (parallel), GSL
+- **Executables produced**: `microsim_gp`, `write_xdmf` (if source present)
+- On systems where HDF5 was built with MPI support (the `h5pcc` wrapper), CMake
+  will find the library automatically via `find_package(HDF5 REQUIRED)`.
+- If your GSL is installed in a non-standard location set `GSL_ROOT_DIR`:
+  ```bash
+  cmake -S . -B build -DGSL_ROOT_DIR=/path/to/gsl
+  ```
+
+### KKS\_CuFFT
+
+- **Languages**: CUDA
+- **Dependencies**: CUDA Toolkit (cuFFT)
+- **Executables produced**: `microsim_kks_cufft`
+- A `DATA/` directory is created in the build folder at configure time to match
+  the solver's expected output path.
+- Set the target GPU architecture with `-DCUDA_ARCH=<sm>` (default: `70`).
+
+### KKS\_FD\_CUDA\_MPI
+
+- **Languages**: C, C++, CUDA
+- **Dependencies**: MPI, HDF5, GSL, CUDA Toolkit (cuFFT or cuFFTMp)
+- **Executables produced**: `microsim_kks_fd_cuda_mpi`, `write_xdmf_kks`,
+  `reconstruct_kks`
+- CUDA **separable compilation** (`-dc` in the original Makefile) is handled
+  automatically by setting `CUDA_SEPARABLE_COMPILATION ON`.
+- To enable multi-GPU cuFFTMp:
+  ```bash
+  cmake -S . -B build \
+        -DENABLE_CUFFTMP=ON \
+        -DCUFFTMP_INCLUDE_DIR=/opt/nvidia/hpc_sdk/.../cufftmp \
+        -DCUFFTMP_LIB_DIR=/opt/nvidia/hpc_sdk/.../math_libs/lib64
+  ```
+
+### KKS\_OpenCl
+
+- **Languages**: C
+- **Dependencies**: MPI, OpenCL, HDF5, GSL
+- **Executables produced**: `microsim_kks_opencl`, `reconstruct_opencl`
+- OpenCL is found via the standard CMake `FindOpenCL` module.  If CMake cannot
+  locate it automatically, set `OpenCL_ROOT`:
+  ```bash
+  cmake -S . -B build -DOpenCL_ROOT=/usr/local/cuda
+  ```
+
+### Cahn\_Hilliard\_FFT\_2D
+
+- **Languages**: C
+- **Dependencies**: FFTW3
+- **Executables produced**: `microsim_ch_fft`
+- FFTW3 is found via the bundled `cmake/FindFFTW3.cmake` module.  If FFTW3 is
+  in a non-standard location set `FFTW3_ROOT`:
+  ```bash
+  cmake -S . -B build -DFFTW3_ROOT=/path/to/fftw3
+  ```
+
+---
+
+## Out-of-Scope Modules
+
+The following modules use build systems tightly coupled to their respective
+frameworks and are **not** migrated to CMake:
+
+| Module | Build system | Reason |
+|---|---|---|
+| `Grand_potential_AMReX/` | AMReX GNUmake | AMReX provides its own Make infrastructure; a CMake port requires [AMReX cmake support](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#cmake) and is a larger effort |
+| `Grand_potential_OpenFOAM/` | OpenFOAM `wmake` | OpenFOAM solvers must be built with `wmake`; CMake is not officially supported |
+| `Bridgman/` | OpenFOAM `wmake` | Same reason as above |
+
+---
+
+## Troubleshooting
+
+### CMake cannot find MPI
+
+```
+CMake Error: Could not find MPI
+```
+
+Ensure that the MPI compilers are on `PATH` (`mpicc`, `mpicxx`) or set
+`MPI_ROOT`:
+
+```bash
+cmake -S . -B build -DMPI_ROOT=/path/to/mpi
+```
+
+### CMake cannot find HDF5
+
+On systems that provide a parallel HDF5 wrapper (e.g., `h5pcc`), tell CMake to
+prefer the parallel variant:
+
+```bash
+HDF5_PREFER_PARALLEL=ON cmake -S . -B build
+```
+
+Or set the hint manually:
+
+```bash
+cmake -S . -B build -DHDF5_ROOT=/path/to/hdf5
+```
+
+### CMake cannot find CUDA
+
+Ensure `nvcc` is on `PATH` or set `CUDAToolkit_ROOT`:
+
+```bash
+cmake -S . -B build -DCUDAToolkit_ROOT=/usr/local/cuda
+```
+
+### CUDA architecture mismatch
+
+If you see PTX/SASS compatibility warnings or errors at runtime, update
+`CUDA_ARCH` to match your GPU:
+
+```bash
+cmake -S . -B build -DCUDA_ARCH=80   # A100, RTX 30xx
+cmake -S . -B build -DCUDA_ARCH=90   # H100
+```
+
+### CMake cannot find FFTW3
+
+```
+CMake Error: Could not find FFTW3
+```
+
+Set `FFTW3_ROOT` to the FFTW3 installation prefix:
+
+```bash
+cmake -S . -B build -DFFTW3_ROOT=/usr/local
+```
+
+Or load the appropriate module on HPC systems:
+
+```bash
+module load fftw3
+cmake -S . -B build
+```


### PR DESCRIPTION
This PR will be useful to install microsim with cmake build system removing hardcoded dependency paths